### PR TITLE
Remove pointless backslash sequence in regex expression

### DIFF
--- a/src/lxrandr.c
+++ b/src/lxrandr.c
@@ -118,7 +118,7 @@ static gboolean get_xrandr_info()
         return FALSE;
     }
 
-    regex = g_regex_new( "\n([-\\.a-zA-Z]+[-\\.0-9]*) +connected ([^(\n ]*)[^\n]*"
+    regex = g_regex_new( "\n([-.a-zA-Z]+[-.0-9]*) +connected ([^(\n ]*)[^\n]*"
                          "((\n +[0-9]+x[0-9]+[^\n]+)+)",
                          0, 0, NULL );
     if( g_regex_match( regex, output, 0, &match ) )


### PR DESCRIPTION
The dot loses its special meaning in classes, so a backslash sequence
is not necessary.