### PR TITLE
Specify NotShowIn instead on OnlyShowIn in Autostart

### DIFF
--- a/data/lxrandr.desktop.in
+++ b/data/lxrandr.desktop.in
@@ -6,5 +6,5 @@ Icon=video-display
 Terminal=false
 Type=Application
 Categories=GTK;Settings;HardwareSettings;X-LXDE-Settings;
-NotShowIn=GNOME;KDE;XFCE;MATE;
+NotShowIn=GNOME;KDE;XFCE;MATE;Budgie;COSMIC;Enlightenment;LXQt;X-Cinnamon;
 _Keywords=screen;display;tv;extend;projector;xrandr;refresh rate;position;enable;disable;

--- a/src/lxrandr.c
+++ b/src/lxrandr.c
@@ -551,7 +551,7 @@ static void save_configuration()
     g_key_file_set_string( kf, grp, "Name", _("LXRandR autostart") );
     g_key_file_set_string( kf, grp, "Comment", _("Start xrandr with settings done in LXRandR") );
     g_key_file_set_string( kf, grp, "Exec", cmd->str );
-    g_key_file_set_string( kf, grp, "NotShowIn", "GNOME;KDE;XFCE;MATE;" );
+    g_key_file_set_string( kf, grp, "NotShowIn", "GNOME;KDE;XFCE;MATE;Budgie;COSMIC;Enlightenment;LXQt;X-Cinnamon;" );
 
     data = g_key_file_to_data(kf, &len, NULL);
     file = g_build_filename(  g_get_user_config_dir(),

--- a/src/lxrandr.c
+++ b/src/lxrandr.c
@@ -551,7 +551,7 @@ static void save_configuration()
     g_key_file_set_string( kf, grp, "Name", _("LXRandR autostart") );
     g_key_file_set_string( kf, grp, "Comment", _("Start xrandr with settings done in LXRandR") );
     g_key_file_set_string( kf, grp, "Exec", cmd->str );
-    g_key_file_set_string( kf, grp, "OnlyShowIn", "LXDE" );
+    g_key_file_set_string( kf, grp, "NotShowIn", "GNOME;KDE;XFCE;MATE;" );
 
     data = g_key_file_to_data(kf, &len, NULL);
     file = g_build_filename(  g_get_user_config_dir(),


### PR DESCRIPTION
This aligns the autostart with the launcher, since it's a generic GUI for xrandr, and not specific for the LXDE session.

Also, exclude some more desktop environments have their own tools to configure the monitor.